### PR TITLE
Update Install Instructions & Variable Conflict Fix

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -7,12 +7,13 @@ Install the system dependencies:
 
     sudo apt install git python-pip libcapstone3 python-dev libffi-dev build-essential virtualenvwrapper graphviz libgraphviz-dev graphviz-dev pkg-config
 
-Install radare2
+Install radare2 v3.1.3
 ---------------
 
 .. code-block:: none
-
-    git clone https://github.com/radare/radare2.git && cd radare2
+    
+    wget https://github.com/radareorg/radare2/archive/refs/tags/3.1.3.zip
+    unzip 3.1.3.zip && cd radare2-3.1.3
     ./sys/install.sh && cd ..
 
 Download the ICSREF repo

--- a/icsref/PRG_analysis.py
+++ b/icsref/PRG_analysis.py
@@ -205,8 +205,8 @@ class Program():
             disasm_data = r2.cmd('pxr {} @{}'.format(length_data ,start_data))
             disasm_data = disasm_data.split('\n')
             # Disassembly formating
-            for i,line in enumerate(disasm_data):
-                disasm_data[i] = '            {}     {}      {}'.format(line[:11], line[14:23], line [14:])
+            for j,line in enumerate(disasm_data):
+                disasm_data[j] = '            {}     {}      {}'.format(line[:11], line[14:23], line [14:])
             disasm = disasm_code + disasm_data
             self.Functions.append(Function(self.path, start_code, stop_data, self.hexdump[start_code:stop_data], disasm))
         r2.quit()


### PR DESCRIPTION
- Doing a fresh install using the latest version of radare2 causes a hang in _find_functions() in PRG_analysis.py at r2.quit(). Updated instructions to use compatible radare2 v3.1.3. This caused ICSREF to be stuck at the "DONE: Find function boundaries" message.
- Minor index variable name conflict resolved in _find_functions()